### PR TITLE
Update cookies

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,5 +15,7 @@
 homepage: "https://bambuser.com"
 documentation: "https://bambuser.com"
 versions:
+  - sha: aae2939c730f063d45503b5eff83c91218e5215b
+    changeNotes: Update access to cookies
   - sha: 2ec11d02305d9a1bd45699436d38336d9e5722bf
     changeNotes: Initial Version

--- a/template.tpl
+++ b/template.tpl
@@ -224,6 +224,10 @@ ___WEB_PERMISSIONS___
               {
                 "type": 1,
                 "string": "_bamls_seid"
+              },
+              {
+                "type": 1,
+                "string": "_bamls_caid"
               }
             ]
           }


### PR DESCRIPTION
A new cookie has been added to be able track purchases from the Bambuser One-To-One product. 
GTM template needs access to this cookie as well.