### PR TITLE
Ensure writing global when property already exists

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@
 homepage: "https://bambuser.com"
 documentation: "https://bambuser.com/docs"
 versions:
+  - sha: 442eda98741e59958558eb35da7b0eaa82aba8f9
+    changeNotes: Fix conflict of writing to global _bambuser object
   - sha: a36da923115f63aadbddc84df4a656462c20c4f5
     changeNotes: Update product naming and add support for Shoppable Videos
   - sha: 957677afd89c9b8ecc37db49aa5050d52fab926f

--- a/template.tpl
+++ b/template.tpl
@@ -822,7 +822,7 @@ if (data.feature === 'conversionTracker') {
           bbu = _bambuser;
         }
         bbu.oneToOneEmbed = oneToOneEmbed;
-        setInWindow('_bambuser', bbu);
+        setInWindow('_bambuser', bbu, true);
       }
       
       data.gtmOnSuccess();


### PR DESCRIPTION
As we load any existing code from window we will not loose any values in it when forcing GTM to overwrite any existing property. This may happen if something else from Bambuser have been loaded before this GTM template, for example the purchase tracking script.

See https://developers.google.com/tag-platform/tag-manager/templates/api#setinwindow and `overrideExisting` parameter