### PR TITLE
Extend template with new shopper events tracking feature

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@
 homepage: "https://bambuser.com"
 documentation: "https://bambuser.com/docs"
 versions:
+  - sha: 986fa98c14037f86c3f66e792269d0210d23028e
+    changeNotes: Support new shopper events tracking
   - sha: 442eda98741e59958558eb35da7b0eaa82aba8f9
     changeNotes: Fix conflict of writing to global _bambuser object
   - sha: a36da923115f63aadbddc84df4a656462c20c4f5

--- a/template.tpl
+++ b/template.tpl
@@ -266,6 +266,11 @@ ___TEMPLATE_PARAMETERS___
         "paramName": "feature",
         "paramValue": "conversionTracker",
         "type": "EQUALS"
+      },
+      {
+        "paramName": "feature",
+        "paramValue": "ecomTracker",
+        "type": "EQUALS"
       }
     ]
   },

--- a/template.tpl
+++ b/template.tpl
@@ -59,7 +59,7 @@ ___TEMPLATE_PARAMETERS___
       }
     ],
     "simpleValueType": true,
-    "defaultValue": "conversionTracker",
+    "defaultValue": "ecomTracker"
   },
   {
     "type": "SELECT",

--- a/template.tpl
+++ b/template.tpl
@@ -37,9 +37,10 @@ ___TEMPLATE_PARAMETERS___
 
 [
   {
-    "type": "RADIO",
+    "type": "SELECT",
     "name": "feature",
-    "radioItems": [
+    "displayName": "Feature",
+    "selectItems": [
       {
         "value": "ecomTracker",
         "displayValue": "Shopper Events Tracking"
@@ -59,7 +60,6 @@ ___TEMPLATE_PARAMETERS___
     ],
     "simpleValueType": true,
     "defaultValue": "conversionTracker",
-    "displayName": "Feature"
   },
   {
     "type": "TEXT",

--- a/template.tpl
+++ b/template.tpl
@@ -62,6 +62,89 @@ ___TEMPLATE_PARAMETERS___
     "defaultValue": "conversionTracker",
   },
   {
+    "type": "SELECT",
+    "name": "ecomEventName",
+    "displayName": "Event name",
+    "macrosInSelect": false,
+    "selectItems": [
+      {
+        "value": "purchase",
+        "displayValue": "Purchase"
+      },
+      {
+        "value": "add-to-cart",
+        "displayValue": "Add to Cart"
+      },
+      {
+        "value": "update-cart",
+        "displayValue": "Update Cart"
+      },
+      {
+        "value": "add-to-wishlist",
+        "displayValue": "Add to Wishlist"
+      },
+      {
+        "value": "remove-from-wishlist",
+        "displayValue": "Remove from Wishlist"
+      },
+      {
+        "value": "product-view",
+        "displayValue": "Product View"
+      },
+      {
+        "value": "refund",
+        "displayValue": "Refund"
+      }
+    ],
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "feature",
+        "paramValue": "ecomTracker",
+        "type": "EQUALS"
+      }
+    ],
+    "valueValidators": [
+      {
+        "type": "NON_EMPTY"
+      }
+    ],
+    "defaultValue": "purchase"
+  },
+  {
+    "type": "TEXT",
+    "name": "transactionObject",
+    "displayName": "Transaction Object",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "ecomEventName",
+        "paramValue": "purchase",
+        "type": "EQUALS"
+      },
+      {
+        "paramName": "ecomEventName",
+        "paramValue": "refund",
+        "type": "EQUALS"
+      }
+    ],
+    "help": "Provide a custom javascript variable object that specifies information about the transaction: \nhttps://bambuser.com/docs/live/shopper-events-tracking/#transaction-object"
+  },
+  {
+    "type": "TEXT",
+    "name": "products",
+    "displayName": "Products array",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "feature",
+        "paramValue": "ecomTracker",
+        "type": "EQUALS"
+      }
+    ],
+    "help": "Provide a custom javascript variable object that specifies information about the products:  https://bambuser.com/docs/live/shopper-events-tracking/#product-object"
+  },
+  {
     "type": "TEXT",
     "name": "orderId",
     "displayName": "Order ID",
@@ -665,7 +748,60 @@ const log = data.debug || data.launchInDebugMode
   ? logToConsole
   : function () {};
 
-if (data.feature === 'conversionTracker') {
+if (data.feature === 'ecomTracker') {
+  // Get the URL the user input into the text field
+  const url = data.scriptUrl || 'https://cdn.liveshopping.bambuser.com/metrics/bambuser.min.js';
+  
+  // If the script loaded successfully, log a message and signal success
+  const onSuccess = () => {
+    log('🧪 Bambuser Debugger 🧪\n', '✅ Tracking Library loaded successfully.');
+    var bbu = copyFromWindow('_bambuser');
+    if (typeof bbu === 'object') {
+      log(data);
+      const gtmInfo = getContainerVersion();
+      const options = {
+        meta: {
+        source: 'gtm-template',
+        customPayload: gtmInfo,
+      }};
+      var eventData = {
+        products: data.products
+      };
+      if (data.ecomEventName === 'purchase' || data.ecomEventName === 'refund') {
+        eventData.transaction = data.transactionObject;
+      }
+      log('Will track data');
+      log(eventData);
+
+      bbu.track(data.ecomEventName, eventData, options).then(() => {
+        log('🧪 Bambuser Debugger 🧪\n', '✅ Tracking successfully sent with the following data:', eventData);
+        data.gtmOnSuccess();
+      }).catch(data.gtmOnFailure);
+      
+    }
+    else {
+      log('🧪 Bambuser Debugger 🧪\n', '❌ Problem with loading the library: ', bbu);
+      data.gtmOnFailure();
+    }
+  };
+
+  // If the script fails to load, log a message and signal failure
+  const onFailure = () => {
+    log('🧪 Bambuser Debugger 🧪\n', '❌ Script load failed.');
+    data.gtmOnFailure();
+  };
+
+  // If the URL input by the user matches the permissions set for the template,
+  // inject the script with the onSuccess and onFailure methods as callbacks.
+  if (queryPermission('inject_script', url)) {
+    log('🧪 Bambuser Debugger 🧪\n', '🔄 Loading the tracking library from ' + url);
+    injectScript(url, onSuccess, onFailure);
+  } else {
+    log('🧪 Bambuser Debugger 🧪\n', '🚫 Script load failed due to permissions mismatch. You may need to whitelist your custom script URL ('+ url +') in the template setting > permissions > Allowed URL match patterns.');
+    data.gtmOnFailure();
+  }
+  
+} else if (data.feature === 'conversionTracker') {
   // LEGACY Conversion tracker
 
   // Get the URL the user input into the text field

--- a/template.tpl
+++ b/template.tpl
@@ -41,8 +41,8 @@ ___TEMPLATE_PARAMETERS___
     "name": "feature",
     "radioItems": [
       {
-        "value": "conversionTracker",
-        "displayValue": "Conversion Tracker"
+        "value": "ecomTracker",
+        "displayValue": "Shopper Events Tracking"
       },
       {
         "value": "oneToOneIntegration",

--- a/template.tpl
+++ b/template.tpl
@@ -51,6 +51,10 @@ ___TEMPLATE_PARAMETERS___
       {
         "value": "vod",
         "displayValue": "Shoppable Video"
+      },
+      {
+        "value": "conversionTracker",
+        "displayValue": "Legacy Conversion Tracker"
       }
     ],
     "simpleValueType": true,
@@ -662,6 +666,7 @@ const log = data.debug || data.launchInDebugMode
   : function () {};
 
 if (data.feature === 'conversionTracker') {
+  // LEGACY Conversion tracker
 
   // Get the URL the user input into the text field
   const url = data.scriptUrl || 'https://cdn.liveshopping.bambuser.com/metrics/bambuser.min.js';


### PR DESCRIPTION
# Summary

This pull request adds support for the new feature to track more ecommerce shopper events such as

- Itemized products in purchase event
- Refund
- Add to cart
- Update cart
- Add to wishlist
- Remove from wishlist
- Product view

It also deprecate the old "conversion tracker" feature that only supported purchase event with limited fields.
We are keeping the option in order to not break current tags configured with that feature.