### PR TITLE
Use track() callbacks to report tracking result to GTM

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@
 homepage: "https://bambuser.com"
 documentation: "https://bambuser.com/docs"
 versions:
+  - sha: 714ded2a245d60a3ac991d6bd4984cd3f8f27e40
+    changeNotes: Pass callbacks to track method to handle tracking result asynchronously
   - sha: 986fa98c14037f86c3f66e792269d0210d23028e
     changeNotes: Support new shopper events tracking
   - sha: 442eda98741e59958558eb35da7b0eaa82aba8f9

--- a/template.tpl
+++ b/template.tpl
@@ -762,13 +762,7 @@ if (data.feature === 'ecomTracker') {
     log('🧪 Bambuser Debugger 🧪\n', '✅ Tracking Library loaded successfully.');
     var bbu = copyFromWindow('_bambuser');
     if (typeof bbu === 'object') {
-      log(data);
-      const gtmInfo = getContainerVersion();
-      const options = {
-        meta: {
-        source: 'gtm-template',
-        customPayload: gtmInfo,
-      }};
+      log('🧪 Bambuser Debugger 🧪\n', 'ℹ️ Attempting to track "' + data.ecomEventName + '" event with the following data:\n', data);
       var eventData = {
         products: data.products
       };
@@ -777,14 +771,36 @@ if (data.feature === 'ecomTracker') {
       }
       log('Will track data');
       log(eventData);
-
-      bbu.track(data.ecomEventName, eventData, options).then(() => {
-        log('🧪 Bambuser Debugger 🧪\n', '✅ Tracking successfully sent with the following data:', eventData);
-        data.gtmOnSuccess();
-      }).catch(data.gtmOnFailure);
-      
-    }
-    else {
+      var logTrackingResult = function (result) {
+        if (getType(result) !== 'object' || typeof result.success !== 'boolean') {
+          log('🧪 Bambuser Debugger 🧪\n', '⚠️ Tracking completed with unknown result!');
+          return;
+        }
+        if (result.success) {
+          log('🧪 Bambuser Debugger 🧪\n', '✅ Tracking successfully completed!');
+        } else {
+          log('🧪 Bambuser Debugger 🧪\n', '❌ Tracking failed! \n', result.message);
+        }
+      };
+      const gtmInfo = getContainerVersion();
+      const options = {
+        meta: {
+          source: 'gtm-template',
+          customPayload: gtmInfo,
+        },
+        callbacks: {
+          onSuccess: function (result) { 
+            logTrackingResult(result); 
+            data.gtmOnSuccess(); 
+          },
+          onFailure: function (result) { 
+            logTrackingResult(result); 
+            data.gtmOnFailure(); 
+          },
+        }
+      };
+      bbu.track(data.ecomEventName, eventData, options);
+    } else {
       log('🧪 Bambuser Debugger 🧪\n', '❌ Problem with loading the library: ', bbu);
       data.gtmOnFailure();
     }


### PR DESCRIPTION
## Summary
- Pass `onSuccess`/`onFailure` as callbacks in options to `bbu.track(eventName, eventData, options)` so the tracking result is reported to GTM asynchronously.
- `gtmOnSuccess` / `gtmOnFailure` are now signaled based on the actual tracking outcome, and the result is logged in debug mode.
- This PR fixes the GTM tag firing status getting stuck on "Still running".

## Test plan
- [ ] Trigger an ecomTracker event and confirm GTM receives success on a successful track.
- [ ] Simulate a failing track and confirm GTM receives failure with the reason logged in debug mode.
- [ ] Verify script-load failure still signals `gtmOnFailure`.
